### PR TITLE
fix(examples): update TextStyle and Button API usage

### DIFF
--- a/examples/button_demo.rs
+++ b/examples/button_demo.rs
@@ -146,7 +146,7 @@ fn main() {
                                                 button("Rounded")
                                                     .with_id(4)
                                                     .corner_radius(20.0)
-                                                    .padding(20.0, 10.0)
+                                                    .padding_xy(20.0, 10.0)
                                                     .background(colors::GREEN_500)
                                                     .hover_background(colors::GREEN_400)
                                                     .press_background(colors::GREEN_600)
@@ -165,7 +165,7 @@ fn main() {
                                             .child(
                                                 button("Large")
                                                     .with_id(6)
-                                                    .padding(24.0, 14.0)
+                                                    .padding_xy(24.0, 14.0)
                                                     .text_size(18.0)
                                                     .background(colors::PURPLE_500)
                                                     .hover_background(colors::PURPLE_400)

--- a/examples/drag_drop_demo.rs
+++ b/examples/drag_drop_demo.rs
@@ -57,6 +57,7 @@ fn main() {
                                         size: 28.0,
                                         color: colors::BLACK,
                                         line_height: 1.2,
+                                        ..Default::default()
                                     },
                                 )
                             )
@@ -67,6 +68,7 @@ fn main() {
                                         size: 14.0,
                                         color: colors::GRAY_600,
                                         line_height: 1.4,
+                                        ..Default::default()
                                     },
                                 )
                             )
@@ -84,6 +86,7 @@ fn main() {
                                                         size: 16.0,
                                                         color: colors::GRAY_700,
                                                         line_height: 1.2,
+                                                        ..Default::default()
                                                     },
                                                 )
                                             )
@@ -102,6 +105,7 @@ fn main() {
                                                         size: 16.0,
                                                         color: colors::GRAY_700,
                                                         line_height: 1.2,
+                                                        ..Default::default()
                                                     },
                                                 )
                                             )
@@ -122,6 +126,7 @@ fn main() {
                                                                 size: 14.0,
                                                                 color: colors::GRAY_500,
                                                                 line_height: 1.2,
+                                                                ..Default::default()
                                                             },
                                                         )
                                                     )
@@ -140,6 +145,7 @@ fn main() {
                                                 size: 14.0,
                                                 color: colors::GRAY_600,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             },
                                         )
                                     )
@@ -150,6 +156,7 @@ fn main() {
                                                 size: 14.0,
                                                 color: colors::GRAY_600,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             },
                                         )
                                     )
@@ -181,6 +188,7 @@ fn draggable_item(label: &str, color: Srgba<f32>) -> impl sol_ui::element::Eleme
                     size: 14.0,
                     color: colors::WHITE,
                     line_height: 1.2,
+                    ..Default::default()
                 },
             )
         )

--- a/examples/persistence_demo.rs
+++ b/examples/persistence_demo.rs
@@ -139,6 +139,7 @@ fn main() {
                                         color: text_color,
                                         size: 28.0,
                                         line_height: 1.2,
+                                        ..Default::default()
                                     },
                                 )
                             )
@@ -149,6 +150,7 @@ fn main() {
                                         color: if current.dark_mode { colors::GRAY_400 } else { colors::GRAY_600 },
                                         size: 12.0,
                                         line_height: 1.2,
+                                        ..Default::default()
                                     },
                                 )
                             )
@@ -163,6 +165,7 @@ fn main() {
                                                 color: secondary_color,
                                                 size: 18.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             },
                                         )
                                     )
@@ -173,6 +176,7 @@ fn main() {
                                                 color: text_color,
                                                 size: 14.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             })
                                             .with_id(1)
                                             .on_change(move |new_state| {
@@ -189,6 +193,7 @@ fn main() {
                                                 color: text_color,
                                                 size: 14.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             })
                                             .checked_background(colors::GREEN_500)
                                             .with_id(2)
@@ -206,6 +211,7 @@ fn main() {
                                                 color: text_color,
                                                 size: 14.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             })
                                             .checked_background(colors::PURPLE_500)
                                             .with_id(3)
@@ -223,6 +229,7 @@ fn main() {
                                                 color: text_color,
                                                 size: 14.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             })
                                             .checked_background(colors::BLUE_500)
                                             .with_id(4)
@@ -243,6 +250,7 @@ fn main() {
                                                 color: secondary_color,
                                                 size: 18.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             },
                                         )
                                     )
@@ -257,7 +265,7 @@ fn main() {
                                                     .press_background(colors::RED_600)
                                                     .text_color(colors::WHITE)
                                                     .corner_radius(8.0)
-                                                    .padding(16.0, 8.0)
+                                                    .padding_xy(16.0, 8.0)
                                                     .with_id(10)
                                                     .on_click_simple(move || {
                                                         dec_settings.borrow_mut().counter -= 1;
@@ -281,6 +289,7 @@ fn main() {
                                                                 color: text_color,
                                                                 size: 20.0,
                                                                 line_height: 1.2,
+                                                                ..Default::default()
                                                             },
                                                         )
                                                     )
@@ -292,7 +301,7 @@ fn main() {
                                                     .press_background(colors::GREEN_600)
                                                     .text_color(colors::WHITE)
                                                     .corner_radius(8.0)
-                                                    .padding(16.0, 8.0)
+                                                    .padding_xy(16.0, 8.0)
                                                     .with_id(11)
                                                     .on_click_simple(move || {
                                                         inc_settings.borrow_mut().counter += 1;
@@ -353,6 +362,7 @@ fn main() {
                                                 color: if current.dark_mode { colors::GRAY_300 } else { colors::GRAY_600 },
                                                 size: 14.0,
                                                 line_height: 1.2,
+                                                ..Default::default()
                                             },
                                         )
                                     )

--- a/examples/reactive_state.rs
+++ b/examples/reactive_state.rs
@@ -148,7 +148,7 @@ fn main() {
                                     .gap(12.0)
                                     .child(
                                         button("-")
-                                            .padding(16.0, 12.0)
+                                            .padding_xy(16.0, 12.0)
                                             .corner_radius(8.0)
                                             .backgrounds(
                                                 colors::RED_500,
@@ -165,7 +165,7 @@ fn main() {
                                     )
                                     .child(
                                         button("Reset")
-                                            .padding(16.0, 12.0)
+                                            .padding_xy(16.0, 12.0)
                                             .corner_radius(8.0)
                                             .backgrounds(
                                                 colors::GRAY_500,
@@ -180,7 +180,7 @@ fn main() {
                                     )
                                     .child(
                                         button("+")
-                                            .padding(16.0, 12.0)
+                                            .padding_xy(16.0, 12.0)
                                             .corner_radius(8.0)
                                             .backgrounds(
                                                 colors::GREEN_500,
@@ -197,7 +197,7 @@ fn main() {
                             // Add 10 button (demonstrates batched updates)
                             .child(
                                 button("+10 (batched)")
-                                    .padding(12.0, 8.0)
+                                    .padding_xy(12.0, 8.0)
                                     .corner_radius(6.0)
                                     .backgrounds(
                                         colors::PURPLE_500,

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -102,7 +102,7 @@ fn main() {
                                 .child(
                                     button("+")
                                         .with_id(1)
-                                        .padding(16.0, 10.0)
+                                        .padding_xy(16.0, 10.0)
                                         .on_click_simple(move || {
                                             *inc.borrow_mut() += 1;
                                         })
@@ -113,7 +113,7 @@ fn main() {
                                         .background(colors::GRAY_700)
                                         .hover_background(colors::GRAY_600)
                                         .press_background(colors::GRAY_800)
-                                        .padding(24.0, 10.0)
+                                        .padding_xy(24.0, 10.0)
                                         .on_click_simple(move || {
                                             *reset.borrow_mut() = 0;
                                         })
@@ -124,7 +124,7 @@ fn main() {
                                         .background(colors::RED_500)
                                         .hover_background(colors::RED_400)
                                         .press_background(colors::RED_600)
-                                        .padding(16.0, 10.0)
+                                        .padding_xy(16.0, 10.0)
                                         .on_click_simple(move || {
                                             *dec.borrow_mut() -= 1;
                                         })


### PR DESCRIPTION
## Summary

- Add `..Default::default()` to TextStyle initializers for new `font_family` and `weight` fields
- Change `.padding(h, v)` to `.padding_xy(h, v)` to match updated Button API

## Files Changed

- `examples/button_demo.rs`
- `examples/drag_drop_demo.rs`
- `examples/persistence_demo.rs`
- `examples/reactive_state.rs`
- `examples/readme_example.rs`

## Test plan

- [x] All examples build successfully (`cargo build --examples`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)