### PR TITLE
fix: Set entity store during input handling

### DIFF
--- a/examples/todo_app.rs
+++ b/examples/todo_app.rs
@@ -179,6 +179,7 @@ fn main() {
                                             color: colors::RED_400.with_alpha(0.3),
                                             size: 64.0,
                                             line_height: 1.2,
+                                            ..Default::default()
                                         },
                                     )),
                             )
@@ -274,6 +275,7 @@ fn main() {
                                                                             },
                                                                             size: 16.0,
                                                                             line_height: 1.2,
+                                                                            ..Default::default()
                                                                         },
                                                                     )),
                                                             )
@@ -291,6 +293,7 @@ fn main() {
                                                                             color: colors::RED_500,
                                                                             size: 20.0,
                                                                             line_height: 1.2,
+                                                                            ..Default::default()
                                                                         },
                                                                     ))
                                                                     .interactive()
@@ -326,6 +329,7 @@ fn main() {
                                                             color: colors::GRAY_400,
                                                             size: 16.0,
                                                             line_height: 1.2,
+                                                            ..Default::default()
                                                         },
                                                     )),
                                             );
@@ -358,6 +362,7 @@ fn main() {
                                                     color: colors::GRAY_500,
                                                     size: 14.0,
                                                     line_height: 1.2,
+                                                    ..Default::default()
                                                 },
                                             ))
                                             // Filter buttons
@@ -407,6 +412,7 @@ fn main() {
                                                                     color: colors::GRAY_500,
                                                                     size: 14.0,
                                                                     line_height: 1.2,
+                                                                    ..Default::default()
                                                                 },
                                                             ))
                                                             .interactive()
@@ -466,6 +472,7 @@ fn filter_button(
                 },
                 size: 14.0,
                 line_height: 1.2,
+                ..Default::default()
             },
         ))
         .interactive()

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use crate::{
-    entity::EntityStore,
+    entity::{EntityStore, clear_entity_store, set_entity_store},
     layer::{InputEvent, LayerManager},
     platform::{create_app_menu, mac::metal_renderer::MetalRenderer, MenuBar, Window},
     task::{TaskRunner, clear_task_runner, set_task_runner},
@@ -273,6 +273,8 @@ impl App {
             }
 
             // Process input events
+            // Set entity store so callbacks can access state during input handling
+            set_entity_store(&mut self.entity_store);
             let input_events = self.window.get_pending_input_events();
             for event in &input_events {
                 // First, call the window event handler if configured
@@ -282,6 +284,8 @@ impl App {
                 // Then pass to layer manager for UI handling
                 self.layer_manager.handle_input(event);
             }
+            // Clear entity store after input - render will set it again
+            clear_entity_store();
 
             let frame_start = Instant::now();
             let _frame_span = info_span!("frame", frame_number = frame_count).entered();


### PR DESCRIPTION
## Summary

- Fixed P0 bug where all interactive callbacks (buttons, checkboxes, etc.) would panic with `with_entity_store called outside render context`
- Root cause: entity store was only set during render phase, but input callbacks fire before render
- Solution: call `set_entity_store()` before processing input events and `clear_entity_store()` after
- Also fixed TextStyle initializers in todo_app.rs (missing `..Default::default()` for new fields)

## Test plan

- [x] `cargo test` passes
- [x] `cargo build --example todo_app` succeeds
- [x] todo_app runs without panic (previously crashed immediately on any click)

Fixes sol-fltp